### PR TITLE
fix: userdata formatting for simple template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,4 @@ repos:
     rev:  v1.4.0
     hooks:
     -   id: detect-secrets
+        args: ['--exclude-lines', 'secretsmanager:'] #don't flag the secretsmanager permissions as sensitive

--- a/cloudformation-templates/zs_cc_cf_template_simple.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_simple.yaml
@@ -231,7 +231,7 @@ Resources:
     Type: 'AWS::EC2::NetworkInterface'
     Properties:
       SubnetId: !Ref CCSubnetID
-      Description: Fn::Join
+      Description: !Join
         - " "
         - - Interface for service traffic for CC
           - !Ref CCInstanceType
@@ -249,7 +249,7 @@ Resources:
     Type: 'AWS::EC2::NetworkInterface'
     Properties:
       SubnetId: !Ref CCSubnetID
-      Description: Fn::Join
+      Description: !Join
         - " "
         - - Interface for service traffic for CC
           - !Ref CCInstanceType
@@ -267,7 +267,7 @@ Resources:
     Type: 'AWS::EC2::NetworkInterface'
     Properties:
       SubnetId: !Ref CCSubnetID
-      Description: Fn::Join
+      Description: !Join
         - " "
         - - Interface for service traffic for CC
           - !Ref CCInstanceType
@@ -301,7 +301,7 @@ Resources:
               Statement:
                 - Effect: Allow
                   Action:
-                    - 'secretsmanager:GetSecretValue'
+                    - 'secretsmanager:GetSecretValue' # pragma: allowlist secret
       ManagedPolicyArns:
         # - 'arn:aws:iam::aws:policy/SecretsManagerReadWrite'
         # SSM policy Commented out for non-poc deployments
@@ -327,22 +327,13 @@ Resources:
         - Key: Name
           Value: !Sub '${AWS::StackName}-CloudConnector'
       UserData: !Base64
-        Fn::Join:
+        'Fn::Join':
           - |+
 
           - - '[ZSCALER]'
-            - Fn::Join
-              - =
-              - - CC_URL
-                - !Ref CloudConnectorProvUrl
-            - Fn::Join
-              - =
-              - - SECRET_NAME
-                - !If [SecretsManagerNameNotEmpty, !Ref SecretManagerSecretName, 'ZS/CC/Credentials']
-            - Fn::Join
-              - =
-              - - HTTP_PROBE_PORT
-                - !If [HttpProbePortNotEmpty, !Ref HttpProbePort, '']
+            - !Join ['=', [ 'CC_URL', !Ref CloudConnectorProvUrl]]
+            - !Join ['=', ['SECRET_NAME', !If [SecretsManagerNameNotEmpty, !Ref SecretManagerSecretName, 'ZS/CC/Credentials']]]
+            - !Join ['=', ['HTTP_PROBE_PORT', !If [HttpProbePortNotEmpty, !Ref HttpProbePort, '']]]
   SrvcNetworkInterfaceAttachment:
     Type: 'AWS::EC2::NetworkInterfaceAttachment'
     Properties:

--- a/cloudformation-templates/zs_cc_cf_template_simple.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_simple.yaml
@@ -301,7 +301,7 @@ Resources:
               Statement:
                 - Effect: Allow
                   Action:
-                    - 'secretsmanager:GetSecretValue' # pragma: allowlist secret
+                    - 'secretsmanager:GetSecretValue'
       ManagedPolicyArns:
         # - 'arn:aws:iam::aws:policy/SecretsManagerReadWrite'
         # SSM policy Commented out for non-poc deployments

--- a/cloudformation-templates/zs_cc_cf_template_zscc_macro.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_zscc_macro.yaml
@@ -53,8 +53,8 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:CreateLogStream
                   - logs:PutLogEvents
-                  - secretsmanager:ListSecrets
-                  - secretsmanager:GetSecretValue
+                  - secretsmanager:ListSecrets  # pragma: allowlist secret
+                  - secretsmanager:GetSecretValue   # pragma: allowlist secret
                 Resource: "*"
               - Effect: Allow
                 Action:

--- a/cloudformation-templates/zs_cc_cf_template_zscc_macro.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_zscc_macro.yaml
@@ -53,8 +53,8 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:CreateLogStream
                   - logs:PutLogEvents
-                  - secretsmanager:ListSecrets  # pragma: allowlist secret
-                  - secretsmanager:GetSecretValue   # pragma: allowlist secret
+                  - secretsmanager:ListSecrets
+                  - secretsmanager:GetSecretValue
                 Resource: "*"
               - Effect: Allow
                 Action:


### PR DESCRIPTION
This fixed 
1. formatting of userdata that was broken when moving from portal to github
2. adding a lint bypass for the word secret appearing in the macro template lambda iam policy