### PR TITLE
refactor: remove Callhome IAM Policy creation as permission is now implicit

### DIFF
--- a/cloudformation-templates/zs_cc_cf_template_simple.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_simple.yaml
@@ -309,19 +309,6 @@ Resources:
             Resource:
               - '*'
 
-  CcCallHomePolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties: 
-      Description: Zscaler Cloud Connector Call Home Policy
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action:
-              - 'sts:AssumeRole'
-            Resource:
-              - 'arn:aws:iam::223544365242:role/callhome-delegation-role'
-
   CcIamRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -339,7 +326,6 @@ Resources:
       ManagedPolicyArns:
         - !Ref CcGetSecretsPolicy
         - !Ref CcSsmControlPolicy
-        - !Ref CcCallHomePolicy
 
 
   CCHostProfile:


### PR DESCRIPTION
removing unnecessary resource creation