### PR TITLE
fix: asg - move cc instance size to ec2 instance type validation from…

### DIFF
--- a/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
@@ -389,6 +389,35 @@ Conditions:
     - !Ref GwlbFlowStickiness
     - "3-tuple"
 
+Rules:
+  smallCCInstanceSize:
+    RuleCondition: !Equals
+      - !Ref ZscalerCcInstanceSize
+      - small
+    Assertions:
+      - Assert:
+          'Fn::Contains':
+            - - t3.medium
+              - t3a.medium
+              - c5a.large
+              - m5n.large
+              - m6i.large
+              - c6i.large
+              - m5n.4xlarge
+              - c5.4xlarge
+              - m6i.4xlarge
+              - c6i.4xlarge
+            - !Ref ZscalerAwsEc2InstanceType
+        AssertDescription: >-
+          For small ZscalerCcInstanceSize, the Instance type must be one of t3.medium, t3a.medium, c5a.large, m5n.large, m6i.large, c6i.large, m5n.4xlarge, c5.4xlarge, m6i.4xlarge, c6i.4xlarge
+  CCProvUrlNotEmpty:
+    Assertions:
+      - Assert: !Not
+          - !Equals
+            - !Ref ZscalerCloudConnectorProvUrl
+            - ''
+    AssertionDescription: Cloud Connector Provisioning URL cannot be empty!
+
 Mappings:
   Product2Code:
     CloudConnector:

--- a/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
@@ -25,7 +25,7 @@ Metadata:
           - ZscalerCloudConnectorProvUrl
           - ZscalerHttpProbePort
       - Label:
-          default: Auto-scaling Group Configuration
+          default: Auto Scaling Group Configuration
         Parameters:
           - AsgS3BucketName
           - AsgS3Key
@@ -41,7 +41,7 @@ Metadata:
           - AsgWarmPoolMaxGroupPreparedCapacity
           - AsgLogGroupRetentionInDays
       - Label:
-          default: Gateway Loadbalancer Configuration
+          default: Gateway Load Balancer Configuration
         Parameters:
           - GwlbTargetGroupRebalanceOnDeregistrationOrUnhealthy
           - GwlbFlowStickiness
@@ -52,30 +52,30 @@ Metadata:
 
     ParameterLabels:
       NetworkVpcId:
-        default: VPC Id
+        default: VPC ID
       NetworkAvailabilityZones:
-        default: Availability Zones to deploy Vms/Gateway LB Eps
+        default: Choose an Availability Zone to Deploy Cloud Connector and GWLB/VPC Endpoints
       NetworkCcSubnetIds:
-        default: Subnet IDs for the Zscaler Cloud Connector ASG
+        default: Subnet ID for the Zscaler Cloud Connector Auto Scaling Group
 
       AsgLaunchTemplateVersion:
-        default: Auto-scaling Group Launch Template Version
+        default: Auto Scaling Group Launch Template Version
       AsgMinSize:
-        default: Auto-scaling Group Minimum Size
+        default: Auto Scaling Group Minimum Size
       AsgMaxSize:
-        default: Auto-scaling Group Maximum Size
+        default: Auto Scaling Group Maximum Size
       AsgWarmPoolReuseOnScaleIn:
-        default: Auto-scaling Group Reuse Instances on Scale In
+        default: Auto Scaling Group Reuse Instances on Scale In
       AsgTargetCpuUtilValue:
-        default: Auto-scaling Group Target Cpu Utilization Value
+        default: Auto Scaling Group Target CPU Utilization Value
       AsgWarmPoolEnabled:
-        default: Auto-scaling Group Warm Pool Enabled
+        default: Auto Scaling Group Warm Pool Enabled
       AsgWarmPoolState:
-        default: Auto-scaling Group Warm Pool State
+        default: Auto Scaling Group Warm Pool State
       AsgWarmPoolMinSize:
-        default: Auto-scaling Group Warm Pool Minimum Size
+        default: Auto Scaling Group Warm Pool Minimum Size
       AsgWarmPoolMaxGroupPreparedCapacity:
-        default: Auto-scaling Group Warm Pool Max Group Prepared Capacity
+        default: Auto Scaling Group Warm Pool Max Group Prepared Capacity
       AsgLogGroupRetentionInDays:
         default: Log Group Retention
       AsgS3BucketName:
@@ -85,38 +85,38 @@ Metadata:
 
 
       GwlbAcceptanceRequiredVpcEps:
-        default: Require acceptance for newly created VPC EPs?
+        default: Require Acceptance For Newly Created VPC Endpoints?
       GwlbCrossZoneLbEnabled:
-        default: Enable Cross-zone Loadbalancing
+        default: Enable Cross-Zone Load Balancing
       GwlbTargetGroupRebalanceOnDeregistrationOrUnhealthy:
-        default: GWLB target failover rebalance strategy
+        default: GWLB Target Failover Rebalance Strategy
       GwlbFlowStickiness:
-        default: GWLB Flow Stickiness strategy
-      GwlbVPCEpServicePrincipals:
-        default: VPC Ep Service Principals
+        default: GWLB Flow Stickiness Strategy
+      GwlbVpcEpServicePrincipals:
+        default: VPC Endpoint Service Principals
       GwlbVpcEpSubnetIds:
-        default: VPC EP Subnets to create VPC EPs in (one per Az)
+        default: VPC Endpoint Subnets to Create VPC Endpoints in (one per AZ)
       
       ZscalerHttpProbePort:
         default: HTTP Monitor Probe Port
       ZscalerKeyPairName:
-        default: Zscaler Cloud Connector instance key pair
+        default: Zscaler Cloud Connector Instance Key Pair
       ZscalerSecretManagerSecretName:
         default: Secrets Manager Secret Name
       ZscalerAwsEc2InstanceType:
-        default: Zscaler Cloud Connector VM AWS EC2 instance type
+        default: Zscaler Cloud Connector AWS EC2 Instance Type
       ZscalerCcInstanceProfile:
         default: Existing IAM Role to use for Zscaler Cloud Connector
       ZscalerCcInstanceSize:
-        default: Zscaler Cloud Connector instance size
+        default: Zscaler Cloud Connector Instance Size
       ZscalerCcMgmtIntfSecurityGroup:
-        default: Zscaler Cloud Connector Mgmt Intf Security Group
+        default: Zscaler Cloud Connector Management Interface Security Group
       ZscalerCcSrvcIntfSecurityGroup:
-        default: Zscaler Cloud Connector Srvc Intf Security Group
+        default: Zscaler Cloud Connector Service Interface Security Group
       ZscalerCloudConnectorProvUrl:
         default: Cloud Connector Provisioning URL
       ZscalerOsAmi:
-        default: Zscaler Product AMI
+        default: Zscaler Cloud Connector AMI
   cfn-lint:
     config:
       ignore_checks:
@@ -140,11 +140,11 @@ Transform:
 
 Parameters:
       NetworkVpcId:
-        Description: "The VPC ID where you want to deploy your Cloud Connector Instances."
+        Description: "The VPC ID where you want to deploy your Cloud Connector Instances"
         Type: 'AWS::EC2::VPC::Id'
       NetworkAvailabilityZones:
         Type: List<AWS::EC2::AvailabilityZone::Name>
-        Description: "A list of required Availability Zones to deploy VMs/Gateway LB EPs"
+        Description: "A list of required Availability Zones to deploy VMs/Gateway LB Endpoints"
       NetworkCcSubnetIds:
         Description: "The subnet where the Zscaler Cloud Connector AMI is deployed."
         Type: List<AWS::EC2::Subnet::Id>
@@ -180,14 +180,14 @@ Parameters:
         Default: 80
       AsgWarmPoolEnabled:
         Type: String
-        Description: "Select \"true\" to enable Auto-scaling Group warm pool (default), else \"false\""
+        Description: "Select \"true\" to enable Auto Scaling Group warm pool (default), else \"false\""
         Default: true
         AllowedValues:
           - true
           - false
       AsgWarmPoolReuseOnScaleIn:
         Type: String
-        Description: "Select \"true\" to enable Auto-scaling Group reuse instance on scale-in, else \"false\" (default)"
+        Description: "Select \"true\" to enable Auto Scaling Group reuse instance on scale-in, else \"false\" (default)"
         Default: false
         AllowedValues:
           - true
@@ -197,7 +197,7 @@ Parameters:
         Description: >-
           Sets the instance state to transition to after the lifecycle hooks finish. 
           Valid values are: Stopped (default), Running or Hibernated. 
-          Ignored when 'Auto-scaling Group Warm Pool Enabled' is No
+          Ignored when 'Auto Scaling Group Warm Pool Enabled' is No
         Default: "Stopped"
         AllowedValues:
           - "Stopped"
@@ -212,7 +212,7 @@ Parameters:
         Description: >-
           Specifies the total maximum number of instances that are allowed to be in the warm pool or in any state except Terminated for the Auto Scaling group. 
           Specify it only if you do not want the warm pool size to be determined by the difference between the group's maximum capacity and its desired capacity. 
-          Ignored when 'Auto-scaling Group Warm Pool Enabled' is No       
+          Ignored when 'Auto Scaling Group Warm Pool Enabled' is No       
       AsgWarmPoolMinSize:
         Type: Number
         MinValue: 0
@@ -223,7 +223,7 @@ Parameters:
         Description: >-
           Specifies the minimum number of instances to maintain in the warm pool. 
           This helps you to ensure that there is always a certain number of warmed instances available to handle traffic spikes. 
-          Ignored when 'Auto-scaling Group Warm Pool Enabled' is No
+          Ignored when 'Auto Scaling Group Warm Pool Enabled' is No
       AsgS3BucketName:
         Type: String
         AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
@@ -242,14 +242,14 @@ Parameters:
       
       GwlbAcceptanceRequiredVpcEps:
         Type: String
-        Description: "Select \"true\" to require acceptance for new VPC EPs, else \"false\" (default)"
+        Description: "Select \"true\" to require acceptance for new VPC Endpoints, else \"false\" (default)"
         Default: false
         AllowedValues:
           - true
           - false
       GwlbCrossZoneLbEnabled:
         Type: String
-        Description: "Select \"true\" to enable cross-zone loadbalancing (default), else \"false\""
+        Description: "Select \"true\" to enable cross-zone load balancing (default), else \"false\""
         Default: true
         AllowedValues:
           - true
@@ -276,14 +276,14 @@ Parameters:
         Description: "[Optional] A List of comma-separated service principal ARNs"
       GwlbVpcEpSubnetIds:
         Description: >- 
-          [Optional] A List of comma-separated VPC EP Subnets to create VPC EPs in (one per Az).
-          Specifying subnets here will override Cloud-connector subnets being used for VPC EPs
+          [Optional] A List of comma-separated VPC EP Subnets to create VPC Endpoints in (one per Az).
+          Specifying subnets here will override Cloud-connector subnets being used for VPC Endpoints
         Default: ""
         Type: CommaDelimitedList
 
       ZscalerAwsEc2InstanceType:
         Type: String
-        Description: "The Amazon EC2 instance type for the ZS instances."
+        Description: "The AWS EC2 instance type for the Cloud Connector instances"
         Default: "m6i.large"
         AllowedValues:
           - t3.medium
@@ -297,7 +297,7 @@ Parameters:
           - m6i.4xlarge
           - c6i.4xlarge
       ZscalerCcInstanceProfile:
-        Description: "[Optional] An Existing IAM Role ARN to use for Cc"
+        Description: "[Optional] An Existing IAM Role ARN to use for Cloud Connector"
         Type: String
         # Default: "arn:aws:iam::223544365242:instance-profile/ASGGWLB3-CcInstanceProfile-hseOMwjBXTSi"
         AllowedPattern: '^$|^arn:aws:iam::[0-9]+:instance-profile/.*$'
@@ -307,10 +307,10 @@ Parameters:
         AllowedValues:
           - "small"
         Default: "small"
-        Description: "The instance type for Zscaler Cloud Connector (small)"
+        Description: "The instance size for Zscaler Cloud Connector (small)"
         Type: String    
       ZscalerCcMgmtIntfSecurityGroup:
-        Description: "[Optional] An Existing Security Group Id to apply to Mgmt Interfaces"
+        Description: "[Optional] An Existing Security Group Id to apply to Managementt Interfaces"
         Type: String
         AllowedPattern: "^$|^sg-[0-9a-f]+$"
         ConstraintDescription: >-
@@ -326,7 +326,7 @@ Parameters:
         ConstraintDescription: >-
           Please input the Cloud Connector Provisioning Template URL to use from
           your Zscaler Cloud Connector Portal
-        Description: "Cloud Connector Prov URL"
+        Description: "Cloud Connector Provisioning URL"
         Type: String
       ZscalerHttpProbePort:
         Type: String
@@ -337,14 +337,14 @@ Parameters:
         Default: 50000
       ZscalerKeyPairName:
         Type: AWS::EC2::KeyPair::KeyName
-        Description: "AWS Ec2 Instance Access KeyPair"
+        Description: "AWS EC2 Instance Access KeyPair"
       ZscalerSecretManagerSecretName:
         Type: String
         Default: "ZS/CC/credentials"
         Description: "Secret Manager Secret Name, defaults to ZS/CC/credentials"
       ZscalerOsAmi:
         Type: AWS::EC2::Image::Id
-        Description: "Amazon EC2 Image Id to use for the deployment"
+        Description: "[Optional] Amazon EC2 Image ID to use for the deployment. Leave empty to deploy the latest marketplace AMI"
 
 Conditions:
   ZscalerSecretsManagerNameNotEmpty: !Not
@@ -713,7 +713,7 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Handler: zscaler_cc_lambda_service.lambda_handler
-      Description: Auto-scaling Group Lambda for Failure management
+      Description: Auto Scaling Group Lambda for Failure management
       Timeout: 180
       MemorySize: 256
       Role: !GetAtt
@@ -915,13 +915,13 @@ Outputs:
           - !GetAtt [ CcInstanceProfile, Arn ]
           - !Ref ZscalerCcInstanceProfile
   ZscalerCcMgmtIntfSecurityGroupInUse:
-    Description: Mgmt Intf Security Group being used by the CcInstances
+    Description: Management Interface Security Group being used by the CcInstances
     Value: !If
             - CreateMgmtIntfSecurityGroup
             - !GetAtt [ MgmtSecurityGroup, GroupId ]
             - !Ref ZscalerCcMgmtIntfSecurityGroup
   ZscalerCcSrvcIntfSecurityGroupInUse:
-    Description: Srvc Intf Security Group being used by the CcInstances
+    Description: Service Interface Security Group being used by the CcInstances
     Value: !If
             - CreateSrvcIntfSecurityGroup
             - !GetAtt [ ServiceSecurityGroup, GroupId ]
@@ -933,5 +933,5 @@ Outputs:
     Description: Zscaler Cloud Connector VPC Endpoint Service
     Value: !Ref CcVpcEpService
   ZscalerCcVpcEp:
-    Description: Use this VPC EP for route nexthops
+    Description: Use this VPC Endpoint for route nexthops
     Value: !Ref CcVpcEp

--- a/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
@@ -24,6 +24,7 @@ Metadata:
           - ZscalerAwsEc2InstanceType
           - ZscalerCloudConnectorProvUrl
           - ZscalerHttpProbePort
+          - ZscalerEBSEncryptionEnabled
       - Label:
           default: Auto Scaling Group Configuration
         Parameters:
@@ -117,6 +118,9 @@ Metadata:
         default: Cloud Connector Provisioning URL
       ZscalerOsAmi:
         default: Zscaler Cloud Connector AMI
+      ZscalerEBSEncryptionEnabled:
+        default: EBS Encryption Enabled
+      
   cfn-lint:
     config:
       ignore_checks:
@@ -345,7 +349,14 @@ Parameters:
       ZscalerOsAmi:
         Type: AWS::EC2::Image::Id
         Description: "[Optional] Amazon EC2 Image ID to use for the deployment. Leave empty to deploy the latest marketplace AMI"
-
+      ZscalerEBSEncryptionEnabled:
+        Type: String
+        Description: "Select \"true\" to enable EBS encryption (default), else \"false\""
+        Default: true
+        AllowedValues:
+          - true
+          - false
+          
 Conditions:
   ZscalerSecretsManagerNameNotEmpty: !Not
     - !Equals 
@@ -561,6 +572,13 @@ Resources:
             Groups: 
               - "Fn::If": [CreateMgmtIntfSecurityGroup, !Ref MgmtSecurityGroup, !Ref ZscalerCcMgmtIntfSecurityGroup]
             AssociatePublicIpAddress: false
+        EbsOptimized: "true"
+        BlockDeviceMappings: 
+          - Ebs:
+              VolumeType: gp3
+              DeleteOnTermination: true
+              Encrypted: !Ref ZscalerEBSEncryptionEnabled
+            DeviceName: /dev/sda1
   
   CcAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup

--- a/cloudformation-templates/zs_cc_cf_template_gwlb.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_gwlb.yaml
@@ -15,15 +15,15 @@ Metadata:
 
     ParameterLabels:
       Ec2Instances:
-        default: ZS CC instance IDs
+        default: Cloud Connector Instance IDs
       Ec2InstancesHttpProbePort:
-        default: ZS CC instance Http Probe Port
+        default: Cloud Connector Instance HTTP Probe Port
       GwlbCrossZoneLbEnabled:
-        default: Enable Cross-zone Loadbalancing
+        default: Enable Cross-Zone Load Balancing
       GwlbTargetGroupRebalanceOnDeregistrationOrUnhealthy:
-        default: GWLB target failover rebalance strategy
+        default: GWLB Target Failover Rebalance Strategy
       GwlbFlowStickiness:
-        default: GWLB Flow Stickiness strategy
+        default: GWLB Flow Stickiness Strategy
   cfn-lint:
     config:
       ignore_checks:
@@ -39,26 +39,24 @@ Parameters:
   Ec2Instances:
     Type: List<AWS::EC2::Instance::Id>
     Description: >-
-      AWS EC2 Instance IDs for ZS Cloud Connectors that are to be added to the
-      GWLB
+      AWS EC2 Instance IDs for Zscaler Cloud Connectors to add to the GWLB Target Group
   Ec2InstancesHttpProbePort:
     Type: String
     AllowedPattern: >-
       ^(80|102[4-9]|10[3-9]\d|1[1-9]\d{2}|[2-9]\d{3}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]\d{2}|655[0-2]\d|6553[0-5])$
     ConstraintDescription: 'The HTTP probe port''s allowed values are [80, 1024-65535]'
     Description: >-
-      The Http Probe Healthcheck Port for ZS Cloud Connectors. Allowed values
-      are [80, 1024-65535]
+      The HTTP Health Check Probe Port. Allowed values are [80, 1024-65535]. This MUST match what was configured in the deployment stack.
   GwlbCrossZoneLbEnabled:
     Type: String
-    Description: "Select \"true\" to enable cross-zone loadbalancing (default), else \"false\""
+    Description: "Select \"true\" to enable cross-zone load balancing (default), else \"false\" to disable"
     Default: true
     AllowedValues:
       - true
       - false
   GwlbTargetGroupRebalanceOnDeregistrationOrUnhealthy:
     Type: String
-    Description: "Select \"rebalance\" to enable rebalance failover on target deregistration or of target becomes unhealthy"
+    Description: "Select \"rebalance\" to enable rebalance failover on target deregistration or if target becomes unhealthy"
     AllowedValues:
       - no_rebalance
       - rebalance

--- a/cloudformation-templates/zs_cc_cf_template_simple.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_simple.yaml
@@ -392,6 +392,13 @@ Resources:
       LaunchTemplate:
         LaunchTemplateId: !Ref CCImdsv2LaunchTemplate
         Version: !GetAtt CCImdsv2LaunchTemplate.LatestVersionNumber
+      EbsOptimized: "true"
+      BlockDeviceMappings: 
+      - DeviceName: "/dev/sda1"
+        Ebs: 
+          VolumeType: "gp3"
+          DeleteOnTermination: "true"
+          Encrypted: "true" #make this a condition
       Tags:
         - Key: Role
           Value: !Sub '${AWS::StackName}-ZSCCInstance'

--- a/cloudformation-templates/zs_cc_cf_template_simple.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_simple.yaml
@@ -6,13 +6,13 @@ Metadata:
   'AWS::CloudFormation::Interface':
     ParameterGroups:
       - Label:
-          default: Network configuration
+          default: Network Configuration
         Parameters:
           - VPCID
           - AvailabilityZone
           - CCSubnetID
       - Label:
-          default: Zscaler Cloud Connector configuration
+          default: Zscaler Cloud Connector Configuration
         Parameters:
           - ZscalerOSAMI
           - KeyPairName
@@ -23,23 +23,25 @@ Metadata:
           - HttpProbePort
     ParameterLabels:
       InstanceType:
-        default: Zscaler Cloud Connector VM AWS EC2 instance type
+        default: Zscaler Cloud Connector AWS EC2 Instance Type
       CCInstanceType:
-        default: Zscaler Cloud Connector instance type
+        default: Zscaler Cloud Connector Instance Size
       KeyPairName:
-        default: Zscaler Cloud Connector instance key pair
+        default: Zscaler Cloud Connector Instance Key Pair
       ZscalerOSAMI:
         default: Zscaler product
       VPCID:
-        default: VPC ID
+        default: Choose a VPC ID to Deploy Cloud Connector
+      AvailabilityZone:
+        default: Choose an Availability Zone to Deploy Cloud Connector
       CCSubnetID:
-        default: Subnet ID of Zscaler Cloud Connector
+        default: Choose a Subnet ID to Deploy Cloud Connector
       CloudConnectorProvUrl:
         default: Cloud Connector Provisioning URL
       ZscalerSecretManagerSecretName:
-        default: Secrets Manager Secret Name (Optional)
+        default: Secrets Manager Secret Name
       HttpProbePort:
-        default: HTTP Monitor Probe Port (Optional)
+        default: HTTP Monitor Probe Port
   cfn-lint:
     config:
       ignore_checks:
@@ -72,7 +74,7 @@ Parameters:
       - m6i.4xlarge
       - c6i.4xlarge
     Default: m6i.large
-    Description: Amazon EC2 instance type for the ZS instances.
+    Description: The AWS EC2 instance type for the Cloud Connector instances
     Type: String
   CCInstanceType:
     AllowedValues:
@@ -80,26 +82,26 @@ Parameters:
       - medium
       - large
     Default: small
-    Description: ZS Cloud Connector Instance type
+    Description: "The instance size for Zscaler Cloud Connector (small)"
     Type: String    
   KeyPairName:
     Type: AWS::EC2::KeyPair::KeyName
-    Description: EC2 Instance Access KeyPair
+    Description: EC2 Instance Access Key Pair
   VPCID:
-    Description: 'ID of the VPC (e.g., vpc-0343606e).'
+    Description: 'The VPC ID where you want to deploy your Cloud Connector Instances'
     Type: 'AWS::EC2::VPC::Id'
   AvailabilityZone:
-    Description: Availability Zone of the subnets
+    Description: Choose an Availability Zone to Deploy Cloud Connector
     Type: 'AWS::EC2::AvailabilityZone::Name'
   CCSubnetID:
-    Description: ID of the Zscaler CC Subnet
+    Description: Must exist in the VPC and availability zone selected in the previous steps
     Type: 'AWS::EC2::Subnet::Id'
   CloudConnectorProvUrl:
     AllowedPattern: '(admin|connector).zs.*.net(/ec)?/w?api/v1/provUrl\?name=[\w-_]+'
     ConstraintDescription: >-
       Please input the Cloud Connector Provisioning Template URL to use from
       your Zscaler Cloud Connector Portal
-    Description: Cloud Connector Prov URL
+    Description: Cloud Connector Provisioning URL
     Type: String
   ZscalerSecretManagerSecretName:
     Type: String
@@ -110,8 +112,9 @@ Parameters:
     Type: String
     AllowedPattern: '^$|^(80|102[4-9]|10[3-9]\d|1[1-9]\d{2}|[2-9]\d{3}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]\d{2}|655[0-2]\d|6553[0-5])$'
     ConstraintDescription: >-
-      When specified, the HTTP probe port's allowed values are [80, 1024-65535]
-    Description: HTTP Monitor probe port to listen on for monitoring probes
+          The HTTP probe port's allowed values are [80, 1024-65535]
+    Description: "HTTP Monitor probe port to listen on for monitoring probes"
+    Default: 50000
 
 Conditions:
   SecretsManagerNameNotEmpty: !Not [!Equals [!Ref ZscalerSecretManagerSecretName, '']]

--- a/cloudformation-templates/zs_cc_cf_template_simple.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_simple.yaml
@@ -21,6 +21,7 @@ Metadata:
           - CloudConnectorProvUrl
           - ZscalerSecretManagerSecretName
           - HttpProbePort
+          - ZscalerEBSEncryptionEnabled
     ParameterLabels:
       InstanceType:
         default: Zscaler Cloud Connector AWS EC2 Instance Type
@@ -42,6 +43,8 @@ Metadata:
         default: Secrets Manager Secret Name
       HttpProbePort:
         default: HTTP Monitor Probe Port
+      ZscalerEBSEncryptionEnabled:
+        default: EBS Encryption Enabled
   cfn-lint:
     config:
       ignore_checks:
@@ -115,6 +118,13 @@ Parameters:
           The HTTP probe port's allowed values are [80, 1024-65535]
     Description: "HTTP Monitor probe port to listen on for monitoring probes"
     Default: 50000
+  ZscalerEBSEncryptionEnabled:
+        Type: String
+        Description: "Select \"true\" to enable EBS encryption (default), else \"false\""
+        Default: true
+        AllowedValues:
+          - true
+          - false
 
 Conditions:
   SecretsManagerNameNotEmpty: !Not [!Equals [!Ref ZscalerSecretManagerSecretName, '']]
@@ -401,7 +411,7 @@ Resources:
         Ebs: 
           VolumeType: "gp3"
           DeleteOnTermination: "true"
-          Encrypted: "true" #make this a condition
+          Encrypted: !Ref ZscalerEBSEncryptionEnabled
       Tags:
         - Key: Role
           Value: !Sub '${AWS::StackName}-ZSCCInstance'

--- a/cloudformation-templates/zs_cc_cf_template_zpa_r53.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_zpa_r53.yaml
@@ -83,7 +83,7 @@ Parameters:
     Default: ZPA
     Type: String
   ApplicationDomainNames:
-    Description: Comma Seperated Application Domain Names(Max 4096 characters)
+    Description: Comma Seperated Application Domain Names (Max 4096 characters)
     Type: CommaDelimitedList
 
 Rules:

--- a/cloudformation-templates/zs_cc_cf_template_zscc_macro.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_zscc_macro.yaml
@@ -534,23 +534,7 @@ Resources:
               logger.error(err)
               responseData["status"] = ["failed", "success"][responseData["status"]=="success" and False]
               responseData["message"] += err
-              
-            # smallCCInstanceSize
-            try:
-              ALLOWED_SIZES = {
-                "small": ["t3.medium", "m5.large", "c5.large", "c5a.large"]
-              }
-              ccInstanceSize = parameters.get("ZscalerCcInstanceSize")
-              awsEc2InstanceType = parameters.get("ZscalerAwsEc2InstanceType")
-              if awsEc2InstanceType not in ALLOWED_SIZES.get(ccInstanceSize):
-                responseData["status"] = ["failed", "success"][responseData["status"]=="success" and False]
-                responseData["message"] += f"\naws Ec2 Insance Type {awsEc2InstanceType} is not valid for CcInstanceSize {ccInstanceSize}, allowed values are {ALLOWED_SIZES.get('ccInstanceSize')}."
-            except Exception as e:
-              err = f"Validating instance sizes errored: {e}"
-              logger.error(err)
-              responseData["status"] = ["failed", "success"][responseData["status"]=="success" and False]
-              responseData["message"] += err
-              
+                            
             # MgmtIntfSecurityGroupIsValid
             try:
               mgmtIntfSecurityGroup = parameters.get("ZscalerCcMgmtIntfSecurityGroup")


### PR DESCRIPTION
The validation for cc instance size to ec2 instance type has been moved from the pre-deployment macro to the asg template as a Rule.