### PR TITLE
fix: httpprobeport default if empty

### DIFF
--- a/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
@@ -337,7 +337,7 @@ Parameters:
         AllowedPattern: '^(80|102[4-9]|10[3-9]\d|1[1-9]\d{2}|[2-9]\d{3}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]\d{2}|655[0-2]\d|6553[0-5])$'
         ConstraintDescription: >-
           The HTTP probe port's allowed values are [80, 1024-65535]
-        Description: "HTTP Monitor probe port to listen on for monitoring probes"
+        Description: "HTTP Monitor probe port to listen on for monitoring probes. Allowed values are 80, 1024-65535. Defaults to 50000"
         Default: 50000
       ZscalerKeyPairName:
         Type: AWS::EC2::KeyPair::KeyName
@@ -551,7 +551,7 @@ Resources:
               - !Join
                 - '='
                 - - 'HTTP_PROBE_PORT'
-                  - !If [ZscalerHttpProbePortNotEmpty, !Ref ZscalerHttpProbePort, '']
+                  - !If [ZscalerHttpProbePortNotEmpty, !Ref ZscalerHttpProbePort, '50000']
         TagSpecifications:
           - ResourceType: instance
             Tags:

--- a/cloudformation-templates/zs_cc_cf_template_simple.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_simple.yaml
@@ -116,7 +116,7 @@ Parameters:
     AllowedPattern: '^$|^(80|102[4-9]|10[3-9]\d|1[1-9]\d{2}|[2-9]\d{3}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]\d{2}|655[0-2]\d|6553[0-5])$'
     ConstraintDescription: >-
           The HTTP probe port's allowed values are [80, 1024-65535]
-    Description: "HTTP Monitor probe port to listen on for monitoring probes"
+    Description: "HTTP Monitor probe port to listen on for monitoring probes. Allowed values are 80, 1024-65535. Defaults to 50000"
     Default: 50000
   ZscalerEBSEncryptionEnabled:
         Type: String
@@ -424,7 +424,7 @@ Resources:
           - - '[ZSCALER]'
             - !Join ['=', [ 'CC_URL', !Ref CloudConnectorProvUrl]]
             - !Join ['=', ['SECRET_NAME', !If [SecretsManagerNameNotEmpty, !Ref ZscalerSecretManagerSecretName, 'ZS/CC/credentials']]]
-            - !Join ['=', ['HTTP_PROBE_PORT', !If [HttpProbePortNotEmpty, !Ref HttpProbePort, '']]]
+            - !Join ['=', ['HTTP_PROBE_PORT', !If [HttpProbePortNotEmpty, !Ref HttpProbePort, '50000']]]
       NetworkInterfaces:
         - NetworkInterfaceId: !Ref 'ServiceXface'
           DeviceIndex: '0'


### PR DESCRIPTION
same as https://github.com/zscaler/cloud-native-aws-cloud-connector-deploy/pull/31 just to develop