### PR TITLE
fix: aws lambda python runtime version update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.61.1 # The version of cfn-lint to use
+    rev: v0.85.2 # The version of cfn-lint to use
     hooks:
     -   id: cfn-python-lint
         files: zs_cc_cf_template_.*\.(json|yml|yaml)$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD - UNRELEASED
+
+BUG FIXES:
+* fix: aws lambda python runtime version update
+
 ## 1.2.0 - 2023-12-16
 
 ------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - UNRELEASED
+## 1.2.1 - 2024-02-22
 
 BUG FIXES:
 * fix: aws lambda python runtime version update

--- a/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
@@ -992,7 +992,7 @@ Outputs:
     Value: ""
   CloudConnectorTemplateVersion:
     Description: Cloud Connector Template Version
-    Value: 1.2.0
+    Value: 1.2.1
   ZscalerCcInstanceProfileInUse:
     Description: IAM role being used by the CcInstances
     Value: !If 

--- a/cloudformation-templates/zs_cc_cf_template_gwlb.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_gwlb.yaml
@@ -162,4 +162,4 @@ Outputs:
     Value: !Ref ZSCCVPCEP
   CloudConnectorGWLBTemplateVersion:
     Description: Cloud Connector Template Version
-    Value: 1.2.0
+    Value: 1.2.1

--- a/cloudformation-templates/zs_cc_cf_template_simple.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_simple.yaml
@@ -537,4 +537,4 @@ Outputs:
     Description: AMI ID In use in the Zscaler Cloud Connector VM
   CloudConnectorTemplateVersion:
     Description: Cloud Connector Template Version
-    Value: 1.2.0
+    Value: 1.2.1

--- a/cloudformation-templates/zs_cc_cf_template_zpa_r53.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_zpa_r53.yaml
@@ -271,4 +271,4 @@ Outputs:
       - ResolverEndpointId
   CloudConnectorZPATemplateVersion:
     Description: Cloud Connector ZPA Template Version
-    Value: 1.2.0
+    Value: 1.2.1

--- a/cloudformation-templates/zs_cc_cf_template_zscc_macro.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_zscc_macro.yaml
@@ -73,7 +73,7 @@ Resources:
       Role: !GetAtt
         - ZSCCMacroExecutionRole
         - Arn
-      Runtime: python3.7
+      Runtime: python3.12
       Code:
         ZipFile: |
           import json

--- a/cloudformation-templates/zs_cc_cf_template_zscc_macro.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_zscc_macro.yaml
@@ -796,4 +796,4 @@ Resources:
 Outputs:
   CloudConnectorMacroTemplateVersion:
     Description: Cloud Connector Macro Template Version
-    Value: 1.2.0
+    Value: 1.2.1


### PR DESCRIPTION
Bumping the python runtime version from 3.7 to 3.12 for macro template. @apandit13 please help verify this.