### PR TITLE
fix: add explicit udp/53 egress security group rule if CFT creates the SG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## TBD - UNRELEASED
+
+------------
+BUG FIXES:
+* fix: add explicit udp/53 egress security group rule if CFT creates the SG 
+
 ## 1.3.3 - 2024-08-30
 
 ------------

--- a/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
@@ -493,6 +493,16 @@ Resources:
           FromPort: 123
           ToPort: 123
           CidrIp: 0.0.0.0/0
+  MgmtEgressRuleUdp53:
+      Condition: CreateMgmtIntfSecurityGroup
+      Type: AWS::EC2::SecurityGroupEgress
+      Properties:
+          Description: "Recommended: CC Mgmt outbound UDP/53"
+          GroupId: !Ref MgmtSecurityGroup
+          IpProtocol: "udp"
+          FromPort: 53
+          ToPort: 53
+          CidrIp: 0.0.0.0/0
   MgmtEgressRuleTcp12002:
       Condition: CreateZsSupportRule
       Type: AWS::EC2::SecurityGroupEgress
@@ -549,6 +559,16 @@ Resources:
           IpProtocol: "udp"
           FromPort: 123
           ToPort: 123
+          CidrIp: 0.0.0.0/0
+  ServiceEgressRuleUdp53:
+      Condition: CreateSrvcIntfSecurityGroup
+      Type: AWS::EC2::SecurityGroupEgress
+      Properties:
+          Description: "Recommended: CC Service outbound UDP 53"
+          GroupId: !Ref ServiceSecurityGroup
+          IpProtocol: "udp"
+          FromPort: 53
+          ToPort: 53
           CidrIp: 0.0.0.0/0
   ServiceEgressRuleUdp6081:
       Condition: CreateSrvcIntfSecurityGroup

--- a/cloudformation-templates/zs_cc_cf_template_simple.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_simple.yaml
@@ -266,6 +266,15 @@ Resources:
           FromPort: 123
           ToPort: 123
           CidrIp: 0.0.0.0/0
+  MgmtEgressRuleUdp53:
+      Type: AWS::EC2::SecurityGroupEgress
+      Properties:
+          Description: "Recommended: CC Mgmt outbound UDP/53"
+          GroupId: !Ref MgmtSecurityGroup
+          IpProtocol: "udp"
+          FromPort: 53
+          ToPort: 53
+          CidrIp: 0.0.0.0/0
   MgmtEgressRuleTcp12002:
       Condition: CreateZsSupportRule
       Type: AWS::EC2::SecurityGroupEgress
@@ -317,6 +326,15 @@ Resources:
           IpProtocol: "udp"
           FromPort: 123
           ToPort: 123
+          CidrIp: 0.0.0.0/0
+  ServiceEgressRuleUdp533:
+      Type: AWS::EC2::SecurityGroupEgress
+      Properties:
+          Description: "Recommended: CC Service outbound UDP 53"
+          GroupId: !Ref ServiceSecurityGroup
+          IpProtocol: "udp"
+          FromPort: 53
+          ToPort: 53
           CidrIp: 0.0.0.0/0
   ServiceEgressRuleUdp6081:
       Type: AWS::EC2::SecurityGroupEgress

--- a/cloudformation-templates/zs_cc_cf_template_zpa_r53.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_zpa_r53.yaml
@@ -40,6 +40,7 @@ Metadata:
         - E3033
         - E1020 # resolver rule ID inputted via macro transform
         - E1151 # resolver rule VPC ID inputted via macro transform
+        - E3031 # resolver rule name inputted via macro transform
 
 Transform:
   - Name: ZSCC-Macro


### PR DESCRIPTION
this is to address AWS not honoring an implicit DNS egress allow if VPC DHCP options sets a custom DNS server
