### PR TITLE
feat: update ASG IAM permissions constraints

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+/.github/ @jmolnar-zscaler
+/.github/ @vkrishnamurthy-zscaler
+/.github/ @syarlagadda-cpu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ ENHANCEMENTS:
 * refactor: restrict default Auto Scaling Group lifecycle action IAM resources to ASGs created by the CloudFormation template
 * refactor: limit CloudWatch PutMetricData permission to the Zscaler/CloudConnectors namespace
 * refactor: update Cloud Tags IAM permissions to required SNS and SQS actions
+* add `FipsEnabled` parameter to simple and ASG CloudFormation templates for enabling FIPS mode via userdata
 
 ## 1.3.3 - 2024-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.4.0 - 2026-05-15
+
+------------
+ENHANCEMENTS:
+* feat: add parameter AsgLifecycleActionWildcardResource to allow explicit opt-out from restricted Auto Scaling Group lifecycle action IAM resources
+* refactor: restrict default Auto Scaling Group lifecycle action IAM resources to ASGs created by the CloudFormation template
+* refactor: limit CloudWatch PutMetricData permission to the Zscaler/CloudConnectors namespace
+* refactor: update Cloud Tags IAM permissions to required SNS and SQS actions
+
 ## 1.3.3 - 2024-08-30
 
 ------------

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This README serves as a quick start guide to deploy Zscaler Cloud Connector reso
 
 Use this repository to create the deployment resources required to deploy and operate Cloud Connector in an existing virtual private cloud (VPC). To learn more about the steps for deploying Cloud Connector using a CloudFormation template, see [Deploying Cloud Connector with Amazon Web Services](https://help.zscaler.com/cloud-connector/deploying-cloud-connector-amazon-web-services).
 
+The Starter Deployment Template and Starter Deployment Template with Auto Scaling and Gateway Load Balancer include an `Enable FIPS Mode` parameter. The default is `False`; select `True` only when deploying Cloud Connectors that should provision with FIPS mode enabled.
+
 ## **1. Pre-Deployment Template**
 
 Before deploying your Cloud Connectors using CloudFormation, you must upload the [**Pre-Deployment Template**](cloudformation-templates/zs_cc_cf_template_zscc_macro.yaml) to the AWS CloudFormation console to create a Pre-Deployment Template Stack.

--- a/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
@@ -44,6 +44,7 @@ Metadata:
           - AsgWarmPoolMinSize
           - AsgWarmPoolMaxGroupPreparedCapacity
           - AsgLogGroupRetentionInDays
+          - AsgLifecycleActionWildcardResource
       - Label:
           default: Gateway Load Balancer Configuration
         Parameters:
@@ -81,6 +82,8 @@ Metadata:
         default: Auto Scaling Group Warm Pool Max Group Prepared Capacity
       AsgLogGroupRetentionInDays:
         default: Log Group Retention
+      AsgLifecycleActionWildcardResource:
+        default: Use Wildcard IAM Resource For ASG Lifecycle Actions
       AsgS3BucketName:
         default: Lambda S3 Bucket Name
       AsgS3Key:
@@ -258,6 +261,13 @@ Parameters:
           Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, and 3653.
         Default: 3
         AllowedValues: [ 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653]
+      AsgLifecycleActionWildcardResource:
+        Type: String
+        Description: "Select \"true\" to grant ASG lifecycle action permissions on all Auto Scaling Groups, else \"false\" to restrict permissions to ASGs created by this template (default)"
+        Default: false
+        AllowedValues:
+          - true
+          - false
       
       GwlbAcceptanceRequiredVpcEps:
         Type: String
@@ -387,6 +397,9 @@ Parameters:
           - false
           
 Conditions:
+  UseAsgLifecycleActionWildcardResource: !Equals
+    - !Ref AsgLifecycleActionWildcardResource
+    - true
   ZscalerSecretsManagerNameNotEmpty: !Not
     - !Equals 
         - !Ref ZscalerSecretManagerSecretName
@@ -647,9 +660,20 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
+              - 'cloudwatch:PutMetricData'
+            Resource:
+              - '*'
+            Condition:
+              StringEquals:
+                'cloudwatch:namespace': 'Zscaler/CloudConnectors'
+          - Effect: Allow
+            Action:
               - 'cloudwatch:GetMetricStatistics'
               - 'cloudwatch:ListMetrics'
-              - 'cloudwatch:PutMetricData'
+            Resource:
+              - '*'
+          - Effect: Allow
+            Action:
               - 'ec2:DescribeTags'
             Resource:
               - '*'
@@ -658,21 +682,26 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Condition: CreateIamAndInstanceProfile
     Properties: 
-      Description: Zscaler Cloud Connector Cloudwatch Metrics Policy
+      Description: Zscaler Cloud Connector Autoscaling Lifecycle Actions Policy
       PolicyDocument:
         Version: 2012-10-17
         Statement:
           - Effect: Allow
             Action:
+              - 'ec2:DescribeInstanceStatus'
               - 'autoscaling:DescribeLifecycleHookTypes'
               - 'autoscaling:DescribeLifecycleHooks'
               - 'autoscaling:DescribeAutoScalingInstances'
-              - 'autoscaling:CompleteLifecycleAction'
-              - 'autoscaling:RecordLifecycleActionHeartbeat'
-              - 'autoscaling:SetInstanceHealth'
-              - 'ec2:DescribeInstanceStatus'
             Resource:
               - '*'
+          - Effect: Allow
+            Action:
+              - 'autoscaling:CompleteLifecycleAction'
+              - 'autoscaling:RecordLifecycleActionHeartbeat'
+            Resource: !If 
+              - UseAsgLifecycleActionWildcardResource
+              - ['*']
+              - - !Sub 'arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${AWS::StackName}-CloudConnectorAutoScalingGroup*'
 
   CcCloudTagsPolicy:
     Condition: CreateCloudTagsIAM
@@ -684,16 +713,12 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
-              - 'sqs:DeleteMessage'
-              - 'sqs:ReceiveMessage'
-              - 'sqs:GetQueueUrl'
-              - 'sqs:GetQueueAttributes'
-              - 'sqs:SetQueueAttributes'
-              - 'sqs:DeleteQueue'
-              - 'sqs:CreateQueue'
-              - 'sns:Subscribe'
+              - 'sns:ListTopics'
               - 'sns:ListSubscriptions'
+              - 'sns:Subscribe'
               - 'sns:Unsubscribe'
+              - 'sqs:CreateQueue'
+              - 'sqs:DeleteQueue'
             Resource:
               - '*'
 

--- a/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
@@ -27,6 +27,7 @@ Metadata:
           - ZscalerAwsEc2InstanceType
           - ZscalerCloudConnectorProvUrl
           - ZscalerHttpProbePort
+          - FipsEnabled
           - ZscalerEBSEncryptionEnabled
       - Label:
           default: Auto Scaling Group Configuration
@@ -105,6 +106,8 @@ Metadata:
       
       ZscalerHttpProbePort:
         default: HTTP Monitor Probe Port
+      FipsEnabled:
+        default: Enable FIPS Mode
       ZscalerKeyPairName:
         default: Zscaler Cloud Connector Instance Key Pair
       ZscalerSecretManagerSecretName:
@@ -364,6 +367,13 @@ Parameters:
           The HTTP probe port's allowed values are [80, 1024-65535]
         Description: "HTTP Monitor probe port for Cloud Connector listen on for monitoring health probes. Allowed values are 80, 1024-65535. Defaults to 50000"
         Default: 50000
+      FipsEnabled:
+        Type: String
+        Description: "Select \"True\" to enable FIPS mode for Cloud Connector provisioning, else \"False\" (default)"
+        Default: "False"
+        AllowedValues:
+          - "True"
+          - "False"
       ZscalerKeyPairName:
         Type: AWS::EC2::KeyPair::KeyName
         Description: "AWS EC2 Instance Access KeyPair"
@@ -780,6 +790,10 @@ Resources:
                 - '='
                 - - 'HTTP_PROBE_PORT'
                   - !If [ZscalerHttpProbePortNotEmpty, !Ref ZscalerHttpProbePort, '50000']
+              - !Join
+                - '='
+                - - 'FIPS_ENABLED'
+                  - !Ref FipsEnabled
         TagSpecifications:
           - ResourceType: instance
             Tags:

--- a/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_asg_gwlb.yaml
@@ -148,6 +148,7 @@ Metadata:
         - W2030 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html#cfn-logs-loggroup-retentionindays
         - E3510 # resource ID of secrets manager inputted from macro transform
         - E3014 # subnet mappings inputted from macro transform
+        - E3681 # VPC ID is inputted from macro transform
 Transform:
   - Name: ZSCC-Macro
     Parameters:

--- a/cloudformation-templates/zs_cc_cf_template_gwlb.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_gwlb.yaml
@@ -32,6 +32,7 @@ Metadata:
         - E3003
         - E2523
         - E3014 # subnet mappings inputted from macro transform
+        - E3681 # VPC ID is inputted from macro transform
 Transform:
   - Name: ZSCC-Macro
     Parameters:

--- a/cloudformation-templates/zs_cc_cf_template_simple.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_simple.yaml
@@ -21,6 +21,7 @@ Metadata:
           - ZscalerCloudConnectorProvUrl
           - ZscalerSecretManagerSecretName
           - HttpProbePort
+          - FipsEnabled
           - ZscalerEBSEncryptionEnabled
           - ZscalerCloudTagsEnabled
           - ZscalerSupportServerRuleEnabled
@@ -46,6 +47,8 @@ Metadata:
         default: Secrets Manager Secret Name
       HttpProbePort:
         default: HTTP Monitor Probe Port
+      FipsEnabled:
+        default: Enable FIPS Mode
       ZscalerEBSEncryptionEnabled:
         default: EBS Encryption Enabled
       ZscalerCloudTagsEnabled:
@@ -128,6 +131,13 @@ Parameters:
           The HTTP probe port's allowed values are [80, 1024-65535]
     Description: "HTTP Monitor probe port to listen on for monitoring probes. Allowed values are 80, 1024-65535. Defaults to 50000"
     Default: 50000
+  FipsEnabled:
+        Type: String
+        Description: "Select \"True\" to enable FIPS mode for Cloud Connector provisioning, else \"False\" (default)"
+        Default: "False"
+        AllowedValues:
+          - "True"
+          - "False"
   ZscalerEBSEncryptionEnabled:
         Type: String
         Description: "Select \"true\" to enable EBS encryption (default), else \"false\""
@@ -580,6 +590,7 @@ Resources:
             - !Join ['=', [ 'CC_URL', !Ref ZscalerCloudConnectorProvUrl]]
             - !Join ['=', ['SECRET_NAME', !If [SecretsManagerNameNotEmpty, !Ref ZscalerSecretManagerSecretName, 'ZS/CC/credentials']]]
             - !Join ['=', ['HTTP_PROBE_PORT', !If [HttpProbePortNotEmpty, !Ref HttpProbePort, '50000']]]
+            - !Join ['=', ['FIPS_ENABLED', !Ref FipsEnabled]]
       NetworkInterfaces:
         - NetworkInterfaceId: !Ref 'ServiceXface'
           DeviceIndex: '0'

--- a/cloudformation-templates/zs_cc_cf_template_simple.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_simple.yaml
@@ -510,16 +510,12 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
-              - 'sqs:DeleteMessage'
-              - 'sqs:ReceiveMessage'
-              - 'sqs:GetQueueUrl'
-              - 'sqs:GetQueueAttributes'
-              - 'sqs:SetQueueAttributes'
-              - 'sqs:DeleteQueue'
-              - 'sqs:CreateQueue'
-              - 'sns:Subscribe'
+              - 'sns:ListTopics'
               - 'sns:ListSubscriptions'
+              - 'sns:Subscribe'
               - 'sns:Unsubscribe'
+              - 'sqs:CreateQueue'
+              - 'sqs:DeleteQueue'
             Resource:
               - '*'
 

--- a/cloudformation-templates/zs_cc_cf_template_zpa_r53.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_zpa_r53.yaml
@@ -62,7 +62,6 @@ Parameters:
   ZscalerCloudName:
     Description: Your Zscaler Cloud Name
     AllowedValues:
-      - ''
       - zspreview.net
       - zsdevel.net
       - zsdemo.net

--- a/cloudformation-templates/zs_cc_cf_template_zpa_r53.yaml
+++ b/cloudformation-templates/zs_cc_cf_template_zpa_r53.yaml
@@ -40,6 +40,7 @@ Metadata:
         - E3033
         - E1020 # resolver rule ID inputted via macro transform
         - E1151 # resolver rule VPC ID inputted via macro transform
+        - E3031
 
 Transform:
   - Name: ZSCC-Macro


### PR DESCRIPTION
* feat: add parameter AsgLifecycleActionWildcardResource to allow explicit opt-out from restricted Auto Scaling Group lifecycle action IAM resources
* refactor: restrict default Auto Scaling Group lifecycle action IAM resources to ASGs created by the CloudFormation template
* refactor: limit CloudWatch PutMetricData permission to the Zscaler/CloudConnectors namespace
* refactor: update Cloud Tags IAM permissions to required SNS and SQS actions